### PR TITLE
feat: P4ADEV-1674 refactor dueDate behaviour on AcaDebtPositionMapper

### DIFF
--- a/src/main/java/it/gov/pagopa/pu/pagopapayments/mapper/AcaDebtPositionMapper.java
+++ b/src/main/java/it/gov/pagopa/pu/pagopapayments/mapper/AcaDebtPositionMapper.java
@@ -1,20 +1,18 @@
 package it.gov.pagopa.pu.pagopapayments.mapper;
 
 import it.gov.pagopa.nodo.pacreateposition.dto.generated.NewDebtPositionRequest;
-import it.gov.pagopa.pu.debtpositions.dto.generated.DebtPositionTypeOrg;
-import it.gov.pagopa.pu.pagopapayments.connector.DebtPositionClient;
 import it.gov.pagopa.pu.pagopapayments.dto.generated.DebtPositionDTO;
 import it.gov.pagopa.pu.pagopapayments.dto.generated.InstallmentDTO;
 import it.gov.pagopa.pu.pagopapayments.dto.generated.PersonDTO;
 import it.gov.pagopa.pu.pagopapayments.dto.generated.TransferDTO;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Component
@@ -24,11 +22,6 @@ public class AcaDebtPositionMapper {
   public static final String STATUS_INSTALLMENT_TO_SYNCH = "TO_SYNCH";
   public static final Set<String> STATUS_TO_SEND_ACA = Set.of(STATUS_INSTALLMENT_TO_SYNCH);
   public static final String STATUS_INSTALLMENT_UNPAID = "UNPAID";
-  private final DebtPositionClient debtPositionClient;
-
-  public AcaDebtPositionMapper(DebtPositionClient debtPositionClient) {
-    this.debtPositionClient = debtPositionClient;
-  }
 
   private boolean installment2sendAca(InstallmentDTO installment, Long organizationId) {
     if (!STATUS_TO_SEND_ACA.contains(installment.getStatus())) {
@@ -48,8 +41,7 @@ public class AcaDebtPositionMapper {
 
   public static final OffsetDateTime MAX_DATE = LocalDateTime.of(2099, 12, 31, 23, 59, 59).atZone(ZoneId.of("Europe/Rome")).toOffsetDateTime();
 
-  public List<NewDebtPositionRequest> mapToNewDebtPositionRequest(DebtPositionDTO debtPosition, String accessToken) {
-    DebtPositionTypeOrg debtPositionTypeOrg = debtPositionClient.getDebtPositionTypeOrgById(debtPosition.getDebtPositionTypeOrgId(), accessToken);
+  public List<NewDebtPositionRequest> mapToNewDebtPositionRequest(DebtPositionDTO debtPosition) {
 
     return debtPosition.getPaymentOptions().stream()
       .flatMap(paymentOption -> paymentOption.getInstallments().stream())
@@ -57,10 +49,8 @@ public class AcaDebtPositionMapper {
       .map(installment -> {
         TransferDTO transfer = installment.getTransfers().getFirst();
         PersonDTO debtor = installment.getDebtor();
-        OffsetDateTime expirationDate = BooleanUtils.isTrue(debtPositionTypeOrg.getFlagMandatoryDueDate()) ?
-          installment.getDueDate() : MAX_DATE;
         return new NewDebtPositionRequest()
-          //.nav() TODO set nav from installment
+          .nav(installment.getNav())
           .iuv(installment.getIuv())
           .paFiscalCode(transfer.getOrgFiscalCode())
           .iban(transfer.getIban())
@@ -70,9 +60,9 @@ public class AcaDebtPositionMapper {
           .entityFullName(debtor.getFullName())
           .description(installment.getRemittanceInformation())
           .amount(installment.getAmountCents().intValue())
-          .expirationDate(expirationDate)
-          .switchToExpired(debtPositionTypeOrg.getFlagMandatoryDueDate())
-          .payStandIn(true); //TODO to verify
+          .expirationDate(Optional.ofNullable(installment.getDueDate()).orElse(MAX_DATE))
+          .switchToExpired(installment.getDueDate()!=null)
+          .payStandIn(true);
       }).toList();
   }
 }

--- a/src/main/java/it/gov/pagopa/pu/pagopapayments/service/aca/AcaService.java
+++ b/src/main/java/it/gov/pagopa/pu/pagopapayments/service/aca/AcaService.java
@@ -41,7 +41,7 @@ public class AcaService {
   }
 
   private void invokePaCreatePositionImpl(DebtPositionDTO debtPosition, OPERATION operation, String accessToken) {
-    List<NewDebtPositionRequest> debtPostionToSendACA = acaDebtPositionMapper.mapToNewDebtPositionRequest(debtPosition, accessToken);
+    List<NewDebtPositionRequest> debtPostionToSendACA = acaDebtPositionMapper.mapToNewDebtPositionRequest(debtPosition);
     Pair<BrokerApiKeys, String> brokerData = brokerService.getBrokerApiKeyAndSegregationCodesByOrganizationId(debtPosition.getOrganizationId(), accessToken);
     debtPostionToSendACA.forEach(newDebtPositionRequest -> {
       if (operation == OPERATION.DELETE) {

--- a/src/main/java/it/gov/pagopa/pu/pagopapayments/service/broker/BrokerService.java
+++ b/src/main/java/it/gov/pagopa/pu/pagopapayments/service/broker/BrokerService.java
@@ -26,7 +26,7 @@ public class BrokerService {
       throw new NotFoundException("organization [%s]".formatted(organizationId));
     }
     BrokerApiKeys apiKeys = organizationClient.getApiKeyByBrokerId(organization.getBrokerId(), accessToken);
-    String segregationCodes = organization.getApplicationCode();
+    String segregationCodes = organization.getSegregationCode();
     return Pair.of(apiKeys, segregationCodes);
   }
 }

--- a/src/test/java/it/gov/pagopa/pu/pagopapayments/connector/OrganizationClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/pu/pagopapayments/connector/OrganizationClientImplTest.java
@@ -40,7 +40,7 @@ class OrganizationClientImplTest {
   private static final Organization VALID_ORG = new Organization()
     .organizationId(VALID_ORG_ID)
     .brokerId(VALID_BROKER_ID)
-    .applicationCode("01");
+    .segregationCode("01");
   private static final BrokerApiKeys VALID_BROKER_API_KEYS = new BrokerApiKeys()
     .acaKey(VALID_ACA_KEY);
 

--- a/src/test/java/it/gov/pagopa/pu/pagopapayments/mapper/AcaDebtPositionMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/pagopapayments/mapper/AcaDebtPositionMapperTest.java
@@ -22,12 +22,6 @@ class AcaDebtPositionMapperTest {
   private static final OffsetDateTime DUE_DATE = OffsetDateTime.now();
   private static final Long TYPE_ORG_ID_EXPIRING = 1L;
   private static final Long TYPE_ORG_ID_NON_EXPIRING = 2L;
-  private static final DebtPositionTypeOrg TYPE_ORG_EXPIRING = new DebtPositionTypeOrg()
-    .debtPositionTypeOrgId(TYPE_ORG_ID_EXPIRING)
-    .flagMandatoryDueDate(true);
-  private static final DebtPositionTypeOrg TYPE_ORG_NON_EXPIRING = new DebtPositionTypeOrg()
-    .debtPositionTypeOrgId(TYPE_ORG_ID_NON_EXPIRING)
-    .flagMandatoryDueDate(false);
 
   @BeforeEach
   void setUp() {

--- a/src/test/java/it/gov/pagopa/pu/pagopapayments/mapper/AcaDebtPositionMapperTest.java
+++ b/src/test/java/it/gov/pagopa/pu/pagopapayments/mapper/AcaDebtPositionMapperTest.java
@@ -2,16 +2,12 @@ package it.gov.pagopa.pu.pagopapayments.mapper;
 
 import it.gov.pagopa.nodo.pacreateposition.dto.generated.NewDebtPositionRequest;
 import it.gov.pagopa.pu.debtpositions.dto.generated.DebtPositionTypeOrg;
-import it.gov.pagopa.pu.pagopapayments.connector.DebtPositionClient;
 import it.gov.pagopa.pu.pagopapayments.dto.generated.*;
-import it.gov.pagopa.pu.pagopapayments.util.TestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.OffsetDateTime;
@@ -19,14 +15,10 @@ import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 class AcaDebtPositionMapperTest {
-  @Mock
-  private DebtPositionClient debtPositionClientMock;
-
   @InjectMocks
   private AcaDebtPositionMapper acaDebtPositionMapper;
 
   private DebtPositionDTO debtPosition;
-  private PersonDTO debtor;
   private static final OffsetDateTime DUE_DATE = OffsetDateTime.now();
   private static final Long TYPE_ORG_ID_EXPIRING = 1L;
   private static final Long TYPE_ORG_ID_NON_EXPIRING = 2L;
@@ -39,7 +31,7 @@ class AcaDebtPositionMapperTest {
 
   @BeforeEach
   void setUp() {
-    debtor = PersonDTO.builder()
+    PersonDTO debtor = PersonDTO.builder()
       .fiscalCode("CF_DEBTOR")
       .entityType("F")
       .fullName("Debtor name")
@@ -104,32 +96,30 @@ class AcaDebtPositionMapperTest {
   @Test
   void givenValidDebtPositionExpiringWhenMapToNewDebtPositionRequestThenOk() {
     //given
-    Mockito.when(debtPositionClientMock.getDebtPositionTypeOrgById(TYPE_ORG_ID_EXPIRING, TestUtils.getFakeAccessToken())).thenReturn(TYPE_ORG_EXPIRING);
+
     //when
-    List<NewDebtPositionRequest> response = acaDebtPositionMapper.mapToNewDebtPositionRequest(debtPosition, TestUtils.getFakeAccessToken());
+    List<NewDebtPositionRequest> response = acaDebtPositionMapper.mapToNewDebtPositionRequest(debtPosition);
     //verify
     Assertions.assertNotNull(response);
     Assertions.assertEquals(2, response.size());
     Assertions.assertEquals(1234, response.get(0).getAmount());
     Assertions.assertEquals(DUE_DATE, response.get(0).getExpirationDate());
     Assertions.assertEquals(DUE_DATE, response.get(1).getExpirationDate());
-    Mockito.verify(debtPositionClientMock, Mockito.times(1)).getDebtPositionTypeOrgById(TYPE_ORG_ID_EXPIRING, TestUtils.getFakeAccessToken());
   }
 
   @Test
   void givenValidDebtPositionNonExpiringWhenMapToNewDebtPositionRequestThenOk() {
     //given
-    debtPosition.setDebtPositionTypeOrgId(TYPE_ORG_ID_NON_EXPIRING);
-    Mockito.when(debtPositionClientMock.getDebtPositionTypeOrgById(TYPE_ORG_ID_NON_EXPIRING, TestUtils.getFakeAccessToken())).thenReturn(TYPE_ORG_NON_EXPIRING);
+    debtPosition.getPaymentOptions().forEach(paymentOption ->
+      paymentOption.getInstallments().forEach(installment -> installment.setDueDate(null)));
     //when
-    List<NewDebtPositionRequest> response = acaDebtPositionMapper.mapToNewDebtPositionRequest(debtPosition, TestUtils.getFakeAccessToken());
+    List<NewDebtPositionRequest> response = acaDebtPositionMapper.mapToNewDebtPositionRequest(debtPosition);
     //verify
     Assertions.assertNotNull(response);
     Assertions.assertEquals(2, response.size());
     Assertions.assertEquals(1234, response.get(0).getAmount());
     Assertions.assertEquals(AcaDebtPositionMapper.MAX_DATE, response.get(0).getExpirationDate());
     Assertions.assertEquals(AcaDebtPositionMapper.MAX_DATE, response.get(1).getExpirationDate());
-    Mockito.verify(debtPositionClientMock, Mockito.times(1)).getDebtPositionTypeOrgById(TYPE_ORG_ID_NON_EXPIRING, TestUtils.getFakeAccessToken());
   }
 
 }

--- a/src/test/java/it/gov/pagopa/pu/pagopapayments/service/AcaServiceTest.java
+++ b/src/test/java/it/gov/pagopa/pu/pagopapayments/service/AcaServiceTest.java
@@ -64,12 +64,12 @@ class AcaServiceTest {
   @Test
   void givenValidDebtPositionWhenCreateThenOk() {
     //given
-    Mockito.when(acaDebtPositionMapperMock.mapToNewDebtPositionRequest(debtPosition, TestUtils.getFakeAccessToken())).thenReturn(newDebtPositionRequestList);
+    Mockito.when(acaDebtPositionMapperMock.mapToNewDebtPositionRequest(debtPosition)).thenReturn(newDebtPositionRequestList);
     Mockito.when(brokerServiceMock.getBrokerApiKeyAndSegregationCodesByOrganizationId(VALID_ORG_ID, TestUtils.getFakeAccessToken())).thenReturn(Pair.of(VALID_API_KEYS, VALID_SEGREGATION_CODE));
     //when
     acaService.create(debtPosition, TestUtils.getFakeAccessToken());
     //verify
-    Mockito.verify(acaDebtPositionMapperMock, Mockito.times(1)).mapToNewDebtPositionRequest(debtPosition, TestUtils.getFakeAccessToken());
+    Mockito.verify(acaDebtPositionMapperMock, Mockito.times(1)).mapToNewDebtPositionRequest(debtPosition);
     Mockito.verify(brokerServiceMock, Mockito.times(1)).getBrokerApiKeyAndSegregationCodesByOrganizationId(VALID_ORG_ID, TestUtils.getFakeAccessToken());
     newDebtPositionRequestList.forEach(newDebtPositionRequest ->
       Mockito.verify(acaClientMock, Mockito.times(1)).paCreatePosition(newDebtPositionRequest, VALID_ACA_KEY, VALID_SEGREGATION_CODE)
@@ -79,12 +79,12 @@ class AcaServiceTest {
   @Test
   void givenValidDebtPositionWhenUpdateThenOk() {
     //given
-    Mockito.when(acaDebtPositionMapperMock.mapToNewDebtPositionRequest(debtPosition, TestUtils.getFakeAccessToken())).thenReturn(newDebtPositionRequestList);
+    Mockito.when(acaDebtPositionMapperMock.mapToNewDebtPositionRequest(debtPosition)).thenReturn(newDebtPositionRequestList);
     Mockito.when(brokerServiceMock.getBrokerApiKeyAndSegregationCodesByOrganizationId(VALID_ORG_ID, TestUtils.getFakeAccessToken())).thenReturn(Pair.of(VALID_API_KEYS, VALID_SEGREGATION_CODE));
     //when
     acaService.update(debtPosition, TestUtils.getFakeAccessToken());
     //verify
-    Mockito.verify(acaDebtPositionMapperMock, Mockito.times(1)).mapToNewDebtPositionRequest(debtPosition, TestUtils.getFakeAccessToken());
+    Mockito.verify(acaDebtPositionMapperMock, Mockito.times(1)).mapToNewDebtPositionRequest(debtPosition);
     Mockito.verify(brokerServiceMock, Mockito.times(1)).getBrokerApiKeyAndSegregationCodesByOrganizationId(VALID_ORG_ID, TestUtils.getFakeAccessToken());
     newDebtPositionRequestList.forEach(newDebtPositionRequest ->
       Mockito.verify(acaClientMock, Mockito.times(1)).paCreatePosition(newDebtPositionRequest, VALID_ACA_KEY, VALID_SEGREGATION_CODE)
@@ -94,13 +94,13 @@ class AcaServiceTest {
   @Test
   void givenValidDebtPositionWhenDeleteThenOk() {
     //given
-    Mockito.when(acaDebtPositionMapperMock.mapToNewDebtPositionRequest(debtPosition, TestUtils.getFakeAccessToken())).thenReturn(newDebtPositionRequestList);
+    Mockito.when(acaDebtPositionMapperMock.mapToNewDebtPositionRequest(debtPosition)).thenReturn(newDebtPositionRequestList);
     Mockito.when(brokerServiceMock.getBrokerApiKeyAndSegregationCodesByOrganizationId(VALID_ORG_ID, TestUtils.getFakeAccessToken())).thenReturn(Pair.of(VALID_API_KEYS, VALID_SEGREGATION_CODE));
     //when
     acaService.delete(debtPosition, TestUtils.getFakeAccessToken());
     //verify
 
-    Mockito.verify(acaDebtPositionMapperMock, Mockito.times(1)).mapToNewDebtPositionRequest(debtPosition, TestUtils.getFakeAccessToken());
+    Mockito.verify(acaDebtPositionMapperMock, Mockito.times(1)).mapToNewDebtPositionRequest(debtPosition);
     Mockito.verify(brokerServiceMock, Mockito.times(1)).getBrokerApiKeyAndSegregationCodesByOrganizationId(VALID_ORG_ID, TestUtils.getFakeAccessToken());
     newDebtPositionRequestList.forEach(newDebtPositionRequest ->
       Mockito.verify(acaClientMock, Mockito.times(1)).paCreatePosition(

--- a/src/test/java/it/gov/pagopa/pu/pagopapayments/service/BrokerServiceTest.java
+++ b/src/test/java/it/gov/pagopa/pu/pagopapayments/service/BrokerServiceTest.java
@@ -30,7 +30,7 @@ class BrokerServiceTest {
   private static final Organization VALID_ORG = new Organization()
     .organizationId(VALID_ORG_ID)
     .brokerId(VALID_BROKER_ID)
-    .applicationCode(VALID_SEGREGATION_CODE);
+    .segregationCode(VALID_SEGREGATION_CODE);
   private static final BrokerApiKeys VALID_API_KEYS = new BrokerApiKeys()
     .acaKey("validAcaKey")
     .syncKey("validSyncKey");


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

refactor dueDate behaviour: DebtPositionTypeOrg.flagMandatoryDueDate() is not involved anymore

#### List of Changes
<!--- Describe your changes in detail -->
refactor dueDate behaviour: DebtPositionTypeOrg.flagMandatoryDueDate() is not involved anymore

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
-

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [X] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [X] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CHORE - Minor Change (fix or feature that don't impact the functionality e.g. Documentation or lint configuration)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
