### PR TITLE
feat: P4ADEV-1719 add implementation of getDebtPositionsByOrganizationIdAndNav

### DIFF
--- a/src/main/java/it/gov/pagopa/pu/pagopapayments/connector/debtpositions/client/DebtPositionClient.java
+++ b/src/main/java/it/gov/pagopa/pu/pagopapayments/connector/debtpositions/client/DebtPositionClient.java
@@ -31,6 +31,8 @@ public class DebtPositionClient {
   }
 
   public List<InstallmentDTO> getDebtPositionsByOrganizationIdAndNav(Long organizationId, String nav, String accessToken) {
-    return List.of(); //TODO blocked by P4ADEV-1779
+    return debtPositionsApisHolder
+      .getInstallmentApi(accessToken)
+      .getInstallmentsByOrganizationIdAndNav(organizationId, nav);
   }
 }

--- a/src/main/java/it/gov/pagopa/pu/pagopapayments/connector/debtpositions/config/DebtPositionsApisHolder.java
+++ b/src/main/java/it/gov/pagopa/pu/pagopapayments/connector/debtpositions/config/DebtPositionsApisHolder.java
@@ -3,6 +3,7 @@ package it.gov.pagopa.pu.pagopapayments.connector.debtpositions.config;
 import it.gov.pagopa.pu.debtpositions.controller.ApiClient;
 import it.gov.pagopa.pu.debtpositions.controller.BaseApi;
 import it.gov.pagopa.pu.debtpositions.controller.generated.DebtPositionTypeOrgEntityControllerApi;
+import it.gov.pagopa.pu.debtpositions.controller.generated.InstallmentApi;
 import it.gov.pagopa.pu.pagopapayments.config.RestTemplateConfig;
 import jakarta.annotation.PreDestroy;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -13,6 +14,8 @@ import org.springframework.web.client.RestTemplate;
 public class DebtPositionsApisHolder {
 
   private final DebtPositionTypeOrgEntityControllerApi debtPositionTypeOrgEntityControllerApi;
+
+  private final InstallmentApi installmentApi;
 
   private final ThreadLocal<String> bearerTokenHolder = new ThreadLocal<>();
 
@@ -31,6 +34,7 @@ public class DebtPositionsApisHolder {
     }
 
     this.debtPositionTypeOrgEntityControllerApi = new DebtPositionTypeOrgEntityControllerApi(apiClient);
+    this.installmentApi = new InstallmentApi(apiClient);
   }
 
   @PreDestroy
@@ -40,6 +44,10 @@ public class DebtPositionsApisHolder {
 
   public DebtPositionTypeOrgEntityControllerApi getDebtPositionTypeOrgEntityControllerApi(String accessToken) {
     return getApi(accessToken, debtPositionTypeOrgEntityControllerApi);
+  }
+
+  public InstallmentApi getInstallmentApi(String accessToken) {
+    return getApi(accessToken, installmentApi);
   }
 
   private <T extends BaseApi> T getApi(String accessToken, T api) {

--- a/src/test/java/it/gov/pagopa/pu/pagopapayments/connector/BaseApiHolderTest.java
+++ b/src/test/java/it/gov/pagopa/pu/pagopapayments/connector/BaseApiHolderTest.java
@@ -38,7 +38,7 @@ public abstract class BaseApiHolderTest {
         try {
           String auth = "auth" + i;
           String authPrefix = AUTH_TYPE.BEARER.equals(authType) ? "Bearer " : "";
-          T expectedResult = apiReturnedType.getConstructor().newInstance();
+          T expectedResult = Mockito.mock(apiReturnedType);
 
           Mockito.doReturn(ResponseEntity.ok(expectedResult))
             .when(restTemplateMock)

--- a/src/test/java/it/gov/pagopa/pu/pagopapayments/connector/debtpositions/client/DebtPositionClientTest.java
+++ b/src/test/java/it/gov/pagopa/pu/pagopapayments/connector/debtpositions/client/DebtPositionClientTest.java
@@ -1,6 +1,7 @@
 package it.gov.pagopa.pu.pagopapayments.connector.debtpositions.client;
 
 import it.gov.pagopa.pu.debtpositions.controller.generated.DebtPositionTypeOrgEntityControllerApi;
+import it.gov.pagopa.pu.debtpositions.controller.generated.InstallmentApi;
 import it.gov.pagopa.pu.debtpositions.dto.generated.DebtPositionTypeOrg;
 import it.gov.pagopa.pu.debtpositions.dto.generated.InstallmentDTO;
 import it.gov.pagopa.pu.pagopapayments.connector.debtpositions.config.DebtPositionsApisHolder;
@@ -24,6 +25,9 @@ class DebtPositionClientTest {
   private DebtPositionsApisHolder apisHolderMock;
   @Mock
   private DebtPositionTypeOrgEntityControllerApi debtPositionTypeOrgEntityControllerApiMock;
+  @Mock
+  private InstallmentApi installmentApiMock;
+
 
   private DebtPositionClient client;
 
@@ -36,7 +40,8 @@ class DebtPositionClientTest {
   void verifyNoMoreInteractions(){
     Mockito.verifyNoMoreInteractions(
       apisHolderMock,
-      debtPositionTypeOrgEntityControllerApiMock
+      debtPositionTypeOrgEntityControllerApiMock,
+      installmentApiMock
       );
   }
 
@@ -84,6 +89,12 @@ class DebtPositionClientTest {
     long organizationId = 1L;
     String nav = "NAV";
     List<InstallmentDTO> expectedResult = List.of();
+
+    Mockito.when(apisHolderMock.getInstallmentApi(accessToken))
+      .thenReturn(installmentApiMock);
+    Mockito.when(installmentApiMock.getInstallmentsByOrganizationIdAndNav(organizationId, nav))
+      .thenReturn(expectedResult);
+
 
     // When
     List<InstallmentDTO> result = client.getDebtPositionsByOrganizationIdAndNav(organizationId, nav, accessToken);

--- a/src/test/java/it/gov/pagopa/pu/pagopapayments/connector/debtpositions/config/DebtPositionsApisHolderTest.java
+++ b/src/test/java/it/gov/pagopa/pu/pagopapayments/connector/debtpositions/config/DebtPositionsApisHolderTest.java
@@ -12,6 +12,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 
+import java.util.List;
+
 @ExtendWith(MockitoExtension.class)
 class DebtPositionsApisHolderTest extends BaseApiHolderTest {
     @Mock
@@ -45,5 +47,14 @@ class DebtPositionsApisHolderTest extends BaseApiHolderTest {
                 DebtPositionTypeOrg.class,
                 apisHolder::unload);
     }
+
+  @Test
+  void whenGetInstallmentApiThenAuthenticationShouldBeSetInThreadSafeMode() throws InterruptedException {
+    assertAuthenticationShouldBeSetInThreadSafeMode(
+      accessToken -> apisHolder.getInstallmentApi(accessToken)
+        .getInstallmentsByOrganizationIdAndNav(1L, "nav"),
+      List.class,
+      apisHolder::unload);
+  }
 
 }


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
add implementation of getDebtPositionsByOrganizationIdAndNav
#### List of Changes
<!--- Describe your changes in detail -->
add implementation of getDebtPositionsByOrganizationIdAndNav
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
add implementation of getDebtPositionsByOrganizationIdAndNav
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [X] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [X] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CHORE - Minor Change (fix or feature that don't impact the functionality e.g. Documentation or lint configuration)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
